### PR TITLE
Less Verbose make Commands (data, lint)

### DIFF
--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -20,7 +20,7 @@ clean:
 	find . -name "*.pyc" -exec rm {} \;
 
 lint:
-	flake8 .
+	flake8 --exclude=lib/,bin/ .
 
 sync_data_to_s3:
 	s3cmd sync --recursive data/ s3://$(BUCKET)/data/

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -11,7 +11,7 @@ BUCKET = {{ cookiecutter.s3_bucket }}
 #################################################################################
 
 requirements:
-	pip install -r requirements.txt
+	pip install -q -r requirements.txt
 
 data: requirements
 	python src/make_dataset.py


### PR DESCRIPTION
By default pip will warn of requirements which are already installed, this fact coupled with the fact that `make data` depends on `requirements` (a good thing) generates a ton of uninteresting output for the task `make data`. I'm proposing pip be made silent as we aren't losing any transparency because make will still print `pip install -q -r requirements.txt` to the command line when executing `make data`.

The second change adds the virtualenv directories which will contain python code to the exclude list for flake8 so as to not generate linter warnings about code not written by the data scientists.