### PR TITLE
Add util func to magically find .env file per #18

### DIFF
--- a/{{ cookiecutter.repo_name }}/src/data/make_dataset.py
+++ b/{{ cookiecutter.repo_name }}/src/data/make_dataset.py
@@ -4,6 +4,8 @@ import click
 import dotenv
 import logging
 
+from utils import find_dotenv
+
 
 @click.command()
 @click.argument('input_filepath', type=click.Path(exists=True))
@@ -18,8 +20,7 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO, format=log_fmt)
 
     project_dir = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
-    dotenv_path = os.path.join(project_dir, '.env')
+    dotenv_path = find_dotenv()
     dotenv.load_dotenv(dotenv_path)
 
     main()
-

--- a/{{ cookiecutter.repo_name }}/src/data/utils.py
+++ b/{{ cookiecutter.repo_name }}/src/data/utils.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+import os
+
+def _walk_to_root(path):
+    """
+    Yield directories starting from the given directory up to the root
+    """
+    if not os.path.exists(path):
+        raise IOError('Starting path not found')
+
+    if os.path.isfile(path):
+        path = os.path.dirname(path)
+
+    last_dir = None
+    current_dir = os.path.abspath(path)
+    while last_dir != current_dir:
+        yield current_dir
+        parent_dir = os.path.abspath(os.path.join(current_dir, os.path.pardir))
+        last_dir, current_dir = current_dir, parent_dir
+
+
+def find_dotenv(filename='.env', raise_error_if_not_found=False, usecwd=False):
+    """
+    Search in increasingly higher folders for the given file
+
+    Returns path to the file if found, or an empty string otherwise
+    """
+    if usecwd or '__file__' not in globals():
+        # should work without __file__, e.g. in REPL or IPython notebook
+        path = os.getcwd()
+    else:
+        # will work for .py files
+        path = os.path.dirname(os.path.abspath(__file__))
+
+    for dirname in _walk_to_root(path):
+        check_path = os.path.join(dirname, filename)
+        if os.path.exists(check_path):
+            return check_path
+
+    if raise_error_if_not_found:
+        raise IOError('File not found')
+
+    return ''


### PR DESCRIPTION
Add `find_dotenv` method that will try to find a .env file by
 1. guessing where to start using `__file__` or the working directory -- allowing this to work in non-file contexts such as IPython notebooks and the REPL, and then
 2. walking up the directory tree looking for the specified file -- called `.env` by default.

This is a bit like the ["filthy magic"](https://github.com/jpadilla/django-dotenv/blob/master/dotenv.py#L44-L46) employed by django-dotenv to serve the same purpose, and allows the user to write `load_dotenv(find_dotenv())` in many contexts.

I've submitted a [PR](https://github.com/theskumar/python-dotenv/pull/23) upstream to `python-dotenv`, but in the meantime it looks good for use in notebooks:
![image](https://cloud.githubusercontent.com/assets/1284973/14932008/74c635ba-0e3e-11e6-9d9e-5219219fcdfc.png)