### PR TITLE
Update commands doc.

### DIFF
--- a/{{ cookiecutter.repo_name }}/docs/commands.rst
+++ b/{{ cookiecutter.repo_name }}/docs/commands.rst
@@ -6,5 +6,5 @@ The Makefile contains the central entry points for common tasks related to this 
 Syncing data to S3
 ^^^^^^^^^^^^^^^^^^
 
-* `make sync_data_to_s3` will use `s3cmd` to recursively sync files in `data/` up to `s3://{{ cookiecutter.s3_bucket }}/data/`.
-* `make sync_data_from_s3` will use `s3cmd` to recursively sync files from `s3://{{ cookiecutter.s3_bucket }}/data/` to `data/`.
+* `make sync_data_to_s3` will use `aws s3 sync` to recursively sync files in `data/` up to `s3://{{ cookiecutter.s3_bucket }}/data/`.
+* `make sync_data_from_s3` will use `aws s3 sync` to recursively sync files from `s3://{{ cookiecutter.s3_bucket }}/data/` to `data/`.


### PR DESCRIPTION
The current Makefile template doesn't use `s3cmd` anymore but `aws s3 sync`.