### PR TITLE
Make `make lint` work for new projects.

### DIFF
--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -20,7 +20,7 @@ clean:
 	find . -name "*.pyc" -exec rm {} \;
 
 lint:
-	flake8 --exclude=lib/,bin/ .
+	flake8 --exclude=lib/,bin/,docs/conf.py .
 
 sync_data_to_s3:
 	aws s3 sync data/ s3://$(BUCKET)/data/

--- a/{{ cookiecutter.repo_name }}/src/data/make_dataset.py
+++ b/{{ cookiecutter.repo_name }}/src/data/make_dataset.py
@@ -19,10 +19,9 @@ if __name__ == '__main__':
 
     # not used in this stub but often useful for finding various files
     project_dir = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
-    
+
     # find .env automagically by walking up directories until it's found, then
     # load up the .env entries as environment variables
     load_dotenv(find_dotenv())
 
     main()
-


### PR DESCRIPTION
With this patch `make lint` wouldn't report errors in newly created projects.