### PR TITLE
Makefile help, specify python interpreter, test environment

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,5 +5,6 @@
     "description": "A short description of the project.",
     "year": "2016",
     "open_source_license": ["MIT", "BSD", "Not open source"],
-    "s3_bucket": "[OPTIONAL] your-bucket-for-syncing-data (do not include 's3://')"
+    "s3_bucket": "[OPTIONAL] your-bucket-for-syncing-data (do not include 's3://')",
+    "python_interpreter": ["python", "python3"]
 }

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -5,13 +5,15 @@
 #################################################################################
 
 BUCKET = {{ cookiecutter.s3_bucket }}
+PROJECT_NAME = {{ cookiecutter.repo_name }}
+PYTHON_INTERPRETER = {{ cookiecutter.python_interpreter }}
 
 #################################################################################
 # COMMANDS                                                                      #
 #################################################################################
 
 ## Install Python Dependencies
-requirements:
+requirements: test_environment
 	pip install -q -r requirements.txt
 
 ## Make Dataset
@@ -33,6 +35,15 @@ sync_data_to_s3:
 ## Download Data from S3
 sync_data_from_s3:
 	aws s3 sync s3://$(BUCKET)/data/ data/
+
+## Set up python interpreter environment
+setup_environment:
+	source /usr/local/bin/virtualenvwrapper.sh; mkvirtualenv $(PROJECT_NAME) --python=$(PYTHON_INTERPRETER)
+	@echo ">>> Activate virtualenv with:\nworkon $(PROJECT_NAME)"
+
+## Test python environment is setup correctly
+test_environment:
+	python test_environment.py
 
 #################################################################################
 # PROJECT RULES                                                                 #

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -10,24 +10,93 @@ BUCKET = {{ cookiecutter.s3_bucket }}
 # COMMANDS                                                                      #
 #################################################################################
 
+## Install Python Dependencies
 requirements:
 	pip install -q -r requirements.txt
 
+## Make Dataset
 data: requirements
 	python src/data/make_dataset.py
 
+## Delete all compiled Python files
 clean:
 	find . -name "*.pyc" -exec rm {} \;
 
+## Lint using flake8
 lint:
 	flake8 --exclude=lib/,bin/,docs/conf.py .
 
+## Upload Data to S3
 sync_data_to_s3:
 	aws s3 sync data/ s3://$(BUCKET)/data/
 
+## Download Data from S3
 sync_data_from_s3:
 	aws s3 sync s3://$(BUCKET)/data/ data/
 
 #################################################################################
 # PROJECT RULES                                                                 #
 #################################################################################
+
+
+
+#################################################################################
+# Self Documenting Commands                                                                #
+#################################################################################
+
+.DEFAULT_GOAL := show-help
+
+# Inspired by <http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html>
+# sed script explained:
+# /^##/:
+# 	* save line in hold space
+# 	* purge line
+# 	* Loop:
+# 		* append newline + line to hold space
+# 		* go to next line
+# 		* if line starts with doc comment, strip comment character off and loop
+# 	* remove target prerequisites
+# 	* append hold space (+ newline) to line
+# 	* replace newline plus comments by `---`
+# 	* print line
+# Separate expressions are necessary because labels cannot be delimited by
+# semicolon; see <http://stackoverflow.com/a/11799865/1968>
+.PHONY: show-help
+show-help:
+	@echo "$$(tput bold)Available rules:$$(tput sgr0)"
+	@echo
+	@sed -n -e "/^## / { \
+		h; \
+		s/.*//; \
+		:doc" \
+		-e "H; \
+		n; \
+		s/^## //; \
+		t doc" \
+		-e "s/:.*//; \
+		G; \
+		s/\\n## /---/; \
+		s/\\n/ /g; \
+		p; \
+	}" ${MAKEFILE_LIST} \
+	| LC_ALL='C' sort --ignore-case \
+	| awk -F '---' \
+		-v ncol=$$(tput cols) \
+		-v indent=19 \
+		-v col_on="$$(tput setaf 6)" \
+		-v col_off="$$(tput sgr0)" \
+	'{ \
+		printf "%s%*s%s ", col_on, -indent, $$1, col_off; \
+		n = split($$2, words, " "); \
+		line_length = ncol - indent; \
+		for (i = 1; i <= n; i++) { \
+			line_length -= length(words[i]) + 1; \
+			if (line_length <= 0) { \
+				line_length = ncol - indent - length(words[i]) - 1; \
+				printf "\n%*s ", -indent, " "; \
+			} \
+			printf "%s ", words[i]; \
+		} \
+		printf "\n"; \
+	}' \
+	| more $(shell test $(shell uname) == Darwin && echo '--no-init --raw-control-chars')

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -14,11 +14,11 @@ PYTHON_INTERPRETER = {{ cookiecutter.python_interpreter }}
 
 ## Install Python Dependencies
 requirements: test_environment
-	pip install -q -r requirements.txt
+	pip install -r requirements.txt
 
 ## Make Dataset
 data: requirements
-	python src/data/make_dataset.py
+	$(PYTHON_INTERPRETER) src/data/make_dataset.py
 
 ## Delete all compiled Python files
 clean:
@@ -38,12 +38,16 @@ sync_data_from_s3:
 
 ## Set up python interpreter environment
 create_environment:
+	@pip install -q virtualenvwrapper
+	@echo ">>> Installing virtualenvwrapper if not already intalled.\nMake sure the following lines are in shell startup file\n\
+	export WORKON_HOME=$HOME/.virtualenvs\nexport PROJECT_HOME=$HOME/Devel\nsource /usr/local/bin/virtualenvwrapper.sh\n"
+
 	source /usr/local/bin/virtualenvwrapper.sh; mkvirtualenv $(PROJECT_NAME) --python=$(PYTHON_INTERPRETER)
 	@echo ">>> New virtualenv created. Activate with:\nworkon $(PROJECT_NAME)"
 
 ## Test python environment is setup correctly
 test_environment:
-	python test_environment.py
+	$(PYTHON_INTERPRETER) test_environment.py
 
 #################################################################################
 # PROJECT RULES                                                                 #

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -37,9 +37,9 @@ sync_data_from_s3:
 	aws s3 sync s3://$(BUCKET)/data/ data/
 
 ## Set up python interpreter environment
-setup_environment:
+create_environment:
 	source /usr/local/bin/virtualenvwrapper.sh; mkvirtualenv $(PROJECT_NAME) --python=$(PYTHON_INTERPRETER)
-	@echo ">>> Activate virtualenv with:\nworkon $(PROJECT_NAME)"
+	@echo ">>> New virtualenv created. Activate with:\nworkon $(PROJECT_NAME)"
 
 ## Test python environment is setup correctly
 test_environment:

--- a/{{ cookiecutter.repo_name }}/test_environment.py
+++ b/{{ cookiecutter.repo_name }}/test_environment.py
@@ -14,8 +14,9 @@ def main():
             REQUIRED_PYTHON))
 
     if system_major != required_major:
-        raise TypeError("This project requires Python {}. Found: {}".format(
-            required_major, sys.version))
+        raise TypeError(
+            "This project requires Python {}. Found: Python {}".format(
+                required_major, sys.version))
     else:
         print(">>> Development environment passes all tests!")
 

--- a/{{ cookiecutter.repo_name }}/test_environment.py
+++ b/{{ cookiecutter.repo_name }}/test_environment.py
@@ -1,0 +1,24 @@
+import sys
+
+REQUIRED_PYTHON = "{{ cookiecutter.python_interpreter }}"
+
+
+def main():
+    system_major = sys.version_info.major
+    if REQUIRED_PYTHON == "python":
+        required_major = 2
+    elif REQUIRED_PYTHON == "python3":
+        required_major = 3
+    else:
+        raise ValueError("Unrecognized python interpreter: {}".format(
+            REQUIRED_PYTHON))
+
+    if system_major != required_major:
+        raise TypeError("This project requires Python {}. Found: {}".format(
+            required_major, sys.version))
+    else:
+        print(">>> Development environment passes all tests!")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This pull request adds  several enhancements:

* [Default rule](https://gist.github.com/klmr/575726c7e05d8780505a) in the Makefile to show the other commands with their descriptions from the comments above.
* Additional variable to the template for setting a python interpreter (python vs python3)
* 2 new Makefile commands
     - `create_environment` new virtualenv with the correct interpreter using `virtualenvwrapper`(optional)
     - `test_environment` tests the python environment before installing requirements