### PR TITLE
#53 Rename IPython to Jupyter

### DIFF
--- a/{{ cookiecutter.repo_name }}/.gitignore
+++ b/{{ cookiecutter.repo_name }}/.gitignore
@@ -66,9 +66,8 @@ target/
 # Pycharm
 .idea
 
-# IPython NB Checkpoints
+# Jupyter NB Checkpoints
 .ipynb_checkpoints/
 
 # exclude data from source control by default
 /data/
-


### PR DESCRIPTION
Closes #53 

I rename IPython to Jupyter in a comment in the template `.gitignore`.