### PR TITLE
Changed findstr to findstring

### DIFF
--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -41,7 +41,7 @@ sync_data_from_s3:
 create_environment:
 ifeq (True,$(IS_ANACONDA))
 		@echo ">>> Detected Anaconda, creating conda environment."
-ifeq (3,$(findstr 3,$(PYTHON_INTERPRETER)))
+ifeq (3,$(findstring 3,$(PYTHON_INTERPRETER)))
 	conda create --name $(PROJECT_NAME) python=3.5
 else
 	conda create --name $(PROJECT_NAME) python=2.7


### PR DESCRIPTION
On Mac with GNU Make 3.81 I had to change `findstr` to `findstring` to get the makefile to correctly read the python version number.