### PR TITLE
Added a rule to build the folders of data/

### DIFF
--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -22,6 +22,10 @@ endif
 requirements: test_environment
 	pip install -r requirements.txt
 
+## Create the data and subfolders
+create_data_folders:
+	for f in external interim processed raw; do mkdir -p data/$$f ; touch data/$$f/.gitkeep ; done
+
 ## Make Dataset
 data: requirements
 	$(PYTHON_INTERPRETER) src/data/make_dataset.py


### PR DESCRIPTION
Hi,

as the data folders are not included in the Github repository, they are not there when the project is cloned. But the Makefile contains commands related to `/data` (and scripts could). I included a rule for creating the missing folders.