### PR TITLE
Use latest stable python3 in conda create

### DIFF
--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -57,7 +57,7 @@ create_environment:
 ifeq (True,$(HAS_CONDA))
 		@echo ">>> Detected conda, creating conda environment."
 ifeq (3,$(findstring 3,$(PYTHON_INTERPRETER)))
-	conda create --name $(PROJECT_NAME) python=3.5
+	conda create --name $(PROJECT_NAME) python=3
 else
 	conda create --name $(PROJECT_NAME) python=2.7
 endif


### PR DESCRIPTION
When running `make create_environment` with `PYTHON_INTERPRETER = python3` and `HAS_CONDA=True`, we should use the latest stable python3, instead of python3.5