### PR TITLE
adds editorconfig

### DIFF
--- a/{{ cookiecutter.repo_name }}/.editorconfig
+++ b/{{ cookiecutter.repo_name }}/.editorconfig
@@ -1,0 +1,21 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+charset = utf-8
+end_of_line = lf
+
+[*.bat]
+indent_style = tab
+end_of_line = crlf
+
+[LICENSE]
+insert_final_newline = false
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Adding an [.editorconfig](http://editorconfig.org/) file as is also done in [audreyr/cookiecutter-pypackage/](https://github.com/audreyr/cookiecutter-pypackage/)  might be a very simple and non intrusive way to introduce more consistency in the code, especially since some of the major IDEs and editors honor its contents.