### PR TITLE
refactor: restrict linting to `src` directory

### DIFF
--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -34,7 +34,7 @@ clean:
 
 ## Lint using flake8
 lint:
-	flake8 --exclude=lib/,bin/,docs/conf.py .
+	flake8 src
 
 ## Upload Data to S3
 sync_data_to_s3:


### PR DESCRIPTION
This is one of a series of PRs that relate to #72.