### PR TITLE
refactor: extend the `make clean` command

### DIFF
--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -30,7 +30,8 @@ data: requirements
 
 ## Delete all compiled Python files
 clean:
-	find . -name "*.pyc" -exec rm {} \;
+	find . -type f -name "*.py[co]" -delete
+	find . -type d -name "__pycache__" -delete
 
 ## Lint using flake8
 lint:


### PR DESCRIPTION
This is one of a series of PRs that relate to #72.

These are the commands used by the oh-my-zsh `pyclean` command. Seem well defined and safe to me.