### PR TITLE
Include gitkeep's

### DIFF
--- a/{{ cookiecutter.repo_name }}/.gitignore
+++ b/{{ cookiecutter.repo_name }}/.gitignore
@@ -70,4 +70,9 @@ target/
 .ipynb_checkpoints/
 
 # exclude data from source control by default
-/data/
+/data/**
+!/data/external/
+!/data/interim/
+!/data/raw/
+!/data/processed/
+!/data/*/.gitkeep


### PR DESCRIPTION
`.gitignore` file in generated cookie excludes whole `/data/` which make all `.gitkeep`s under `/data/external/, /data/interim/ etc.` being ignored.

This PR will let `.gitignore` ignore whole data under `/data/` directory except `.gitkeep`s under four specific data directories `external, interim, raw, processed`.

please review 🙏 