### PR TITLE
Spyder and VSCode project folders in .gitignore

### DIFF
--- a/{{ cookiecutter.repo_name }}/.gitignore
+++ b/{{ cookiecutter.repo_name }}/.gitignore
@@ -66,6 +66,12 @@ target/
 # Pycharm
 .idea
 
+# VS Code
+.vscode/
+
+# Spyder
+.spyproject/
+
 # Jupyter NB Checkpoints
 .ipynb_checkpoints/
 


### PR DESCRIPTION
Added Spyder and VSCode project folders to .gitignore:

.vscode/
.spyproject/