### PR TITLE
Change version in setup.py to 0.1.0

### DIFF
--- a/{{ cookiecutter.repo_name }}/setup.py
+++ b/{{ cookiecutter.repo_name }}/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 setup(
     name='src',
     packages=find_packages(),
-    version='0.0.1',
+    version='0.1.0',
     description='{{ cookiecutter.description }}',
     author='{{ cookiecutter.author_name }}',
     license='{% if cookiecutter.open_source_license == 'MIT' %}MIT{% elif cookiecutter.open_source_license == 'BSD-3-Clause' %}BSD-3{% endif %}',


### PR DESCRIPTION
In `setup.py` the version is currently `0.0.1`. For [semantic versioning](https://semver.org/) the version numbers should correspond to `MAJOR.MINOR.PATCH`, with `PATCH` only being incremented for bugfixes. Since the initial development is not a bugfix but the first minor version, I think it would help encourage best practices in versioning to change the initial version in the template to `0.1.0`.

Thoughts?