### PR TITLE
Expand Setup Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ docs/site/
 # test cache
 .cache/*
 tests/__pycache__/*
+*.pytest_cache/

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,35 @@
+import pytest
+import shutil
+from pathlib import Path
+from cookiecutter import main
+
+CCDS_ROOT = Path(__file__).parents[1].resolve()
+
+args = {
+        'project_name': 'DataDriven',
+        'author_name': 'DataDriven',
+        'open_source_license': 'BSD-3-Clause',
+        'python_interpreter': 'python'
+        }
+
+
+@pytest.fixture(scope='class', params=[{}, args])
+def default_baked_project(tmpdir_factory, request):
+    temp = tmpdir_factory.mktemp('data-project')
+    out_dir = Path(temp).resolve()
+
+    pytest.param = request.param
+    main.cookiecutter(
+        str(CCDS_ROOT),
+        no_input=True,
+        extra_context=pytest.param,
+        output_dir=out_dir
+    )
+
+    pn = pytest.param.get('project_name') or 'project_name'
+    proj = out_dir / pn
+    request.cls.path = proj
+    yield 
+
+    # cleanup after
+    shutil.rmtree(out_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import sys
 import pytest
 import shutil
 from pathlib import Path
@@ -11,6 +12,13 @@ args = {
         'open_source_license': 'BSD-3-Clause',
         'python_interpreter': 'python'
         }
+
+
+def system_check(basename):
+    platform = sys.platform
+    if 'linux' in platform:
+        basename = basename.lower()
+    return basename
 
 
 @pytest.fixture(scope='class', params=[{}, args])
@@ -27,6 +35,10 @@ def default_baked_project(tmpdir_factory, request):
     )
 
     pn = pytest.param.get('project_name') or 'project_name'
+    
+    # project name gets converted to lower case on Linux but not Mac
+    pn = system_check(pn)
+
     proj = out_dir / pn
     request.cls.path = proj
     yield 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,8 @@ from cookiecutter import main
 CCDS_ROOT = Path(__file__).parents[1].resolve()
 
 args = {
-        'project_name': 'DataDriven',
-        'author_name': 'DataDriven',
+        'project_name': 'DrivenData',
+        'author_name': 'DrivenData',
         'open_source_license': 'BSD-3-Clause',
         'python_interpreter': 'python'
         }

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -26,7 +26,7 @@ class TestCookieSetup(object):
     def test_project_name(self):
         project = self.path
         if pytest.param.get('project_name'):
-            assert project.name == 'DataDriven'
+            assert project.name == 'DrivenData'
         else:
             assert project.name == 'project_name'
 
@@ -35,7 +35,7 @@ class TestCookieSetup(object):
         args = ['python', setup_, '--author']
         p = check_output(args).decode('ascii').strip()
         if pytest.param.get('author_name'):
-            assert p == 'DataDriven'
+            assert p == 'DrivenData'
         else:
             assert p == 'Your name (or your organization/company/team)'
 
@@ -45,7 +45,7 @@ class TestCookieSetup(object):
         assert no_curlies(readme_path)
         if pytest.param.get('project_name'):
             with open(readme_path) as fin:
-                assert 'DataDriven' == next(fin).strip()
+                assert 'DrivenData' == next(fin).strip()
 
     def test_setup(self):
         setup_ = self.path / 'setup.py'

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 from subprocess import check_output
+from conftest import system_check
 
 
 def no_curlies(filepath):
@@ -26,7 +27,8 @@ class TestCookieSetup(object):
     def test_project_name(self):
         project = self.path
         if pytest.param.get('project_name'):
-            assert project.name == 'DrivenData'
+            name = system_check('DrivenData')
+            assert project.name == name
         else:
             assert project.name == 'project_name'
 


### PR DESCRIPTION
Part of our Data Days for Good initiative was to work on this repo. One of the requested additions was fleshing out the setup tests a little bit more to test for what would happen if user input was introduced. This was mentioned by Isaac. I have separated out the fixture and put it in it's own file, which is discoverable by `pytest` and mentioned in the docs. I have also increased the scope of creating the temp directory to be a class scope so it doesn't have to create it and tear it down after every function call. Lastly I also test for certain conditions given user input. 