### PR TITLE
fixed gitignore typo

### DIFF
--- a/{{ cookiecutter.repo_name }}/.gitignore
+++ b/{{ cookiecutter.repo_name }}/.gitignore
@@ -41,7 +41,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
-*,cover
+*.cover
 
 # Translations
 *.mo


### PR DESCRIPTION
Unless there is some odd comma syntax I don't know about, it seems there is a typo in the .gitignore file.