### PR TITLE
Added support for auto-creation of conda environments

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,17 @@
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - conda
+  - click
+  - Sphinx
+  - coverage
+  - awscli
+  - flake8
+  - python-dotenv
+  - setuptools
+  - wheel
+  - pip
+  - pip:
+    - cython
+    - -e .

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -55,13 +55,15 @@ else
 endif
 
 ## Set up python interpreter environment
-create_environment:
+create_environment: test_environment
 ifeq (True,$(HAS_CONDA))
 		@echo ">>> Detected conda, creating conda environment."
 ifeq (3,$(findstring 3,$(PYTHON_INTERPRETER)))
 	conda create --name $(PROJECT_NAME) python=3
+	conda env update --name $(PROJECT_NAME) -f environment.yml
 else
 	conda create --name $(PROJECT_NAME) python=2.7
+	conda env update --name $(PROJECT_NAME) -f environment.yml
 endif
 		@echo ">>> New conda env created. Activate with:\nsource activate $(PROJECT_NAME)"
 else


### PR DESCRIPTION
This is one possible resolution for #168 .

This PR updates the `Makefile requirements` target with logic for selecting package and environment managers. If conda is detected, a conda environment is created and then updated with a new `environment.yml` file. If conda is not detected, `requirements.txt` is installed with pip and then an environment is created with virtualenv as before.

The conda condition successfully creates the environment and the local package `src` is available in the jupyter kernel in jupyter lab. I can run the notebook cell described in #168 without an error. 

I have not tested the virtualenv condition as I am unfamiliar with it's normal behavior.