### PR TITLE
Fixed test_folders test to check for new folders in repository

### DIFF
--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -109,5 +109,5 @@ class TestCookieSetup(object):
 
         abs_expected_dirs = [str(self.path / d) for d in expected_dirs]
         abs_dirs, _, _ = list(zip(*os.walk(self.path)))
-        assert len(set(abs_expected_dirs + ignored_dirs) - set(abs_dirs)) == 0
+        assert len(set(abs_expected_dirs + ignored_dirs) ^ set(abs_dirs)) == 0
 


### PR DESCRIPTION
Changed from set difference to set symmetric difference. Test will now fail if there are more folders in the repository than listed in the expected_dirs variable.