### PR TITLE
Remove source `which virtualenvwrapper.sh` from Makefile

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,7 +95,6 @@ jobs:
       python -m pip install --upgrade pip
       pip install -r requirements.txt
       pip install -r dev-requirements.txt
-      pip install virtualenvwrapper-win
       pip install -e .
     displayName: 'Install dependencies'
 

--- a/tests/virtualenv_harness.sh
+++ b/tests/virtualenv_harness.sh
@@ -26,25 +26,23 @@ export WORKON_HOME=$TEMP_ENV_ROOT
 # virtualenvwrapper.sh must be on the PATH on the test host machine,
 # which should be the case if virtualenvwrapper is pip installed in
 # the base Python
-# if [ -z $(which virtualenvwrapper.sh) ]; then
-#     for path in ${PATH//:/ }; do
-#         if [ -d "$path" ]; then
-#             echo "Searching $path for virtualenvwrapper.sh"
-#             FIND_RESULT=$(find $path -maxdepth 1 -name "virtualenvwrapper.sh")
-#             if [[ "$FIND_RESULT" ]]; then
-#                 VIRTUALENVWRAPPER_SCRIPT=$FIND_RESULT
-#                 echo VIRTUALENVWRAPPER_SCRIPT=$VIRTUALENVWRAPPER_SCRIPT
-#                 # Add shebang to top of virtualenvwrapper.sh
-#                 # Windows bash needs this to know it's executable
-#                 sed -i '1s/^/#!\/bin\/sh\n/' "$VIRTUALENVWRAPPER_SCRIPT"
-#                 head "$VIRTUALENVWRAPPER_SCRIPT"
-#                 break
-#             fi
-#         fi
-#     done
-# fi
+if [ -z $(which virtualenvwrapper.sh) ]; then
+    for path in ${PATH//:/ }; do
+        if [ -d "$path" ]; then
+            echo "Searching $path for virtualenvwrapper.sh"
+            FIND_RESULT=$(find $path -maxdepth 1 -name "virtualenvwrapper.sh")
+            if [[ "$FIND_RESULT" ]]; then
+                VIRTUALENVWRAPPER_SCRIPT=$FIND_RESULT
+                echo VIRTUALENVWRAPPER_SCRIPT=$VIRTUALENVWRAPPER_SCRIPT
+                break
+            fi
+        fi
+    done
+else
+    VIRTUALENVWRAPPER_SCRIPT=$(which virtualenvwrapper.sh)
+fi
 
-source $(which virtualenvwrapper.sh)
+source "$VIRTUALENVWRAPPER_SCRIPT"
 
 make create_environment
 

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -73,7 +73,7 @@ create_environment:
 	{% endif %}
 	@echo ">>> conda env created. Activate with:\nconda activate $(PROJECT_NAME)"
 	{% elif cookiecutter.environment_manager == 'virtualenv' -%}
-	@bash -c "source `which virtualenvwrapper.sh`;mkvirtualenv $(PROJECT_NAME) --python=$(PYTHON_INTERPRETER)"
+	@bash -c "mkvirtualenv $(PROJECT_NAME) --python=$(PYTHON_INTERPRETER)"
 	@echo ">>> New virtualenv created. Activate with:\nworkon $(PROJECT_NAME)"
 	{% elif cookiecutter.environment_manager == 'pipenv' -%}
 	pipenv --python $(PYTHON_VERSION)


### PR DESCRIPTION
`which virtualenvwrapper.sh` fails on Windows. I propose we remove it from the Makefile command. This means that CCDS assumes a user has virtualenvwrapper set up properly in their shell startup configuration. 