### PR TITLE
Tox reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The directory structure of your new project looks like this:
 │   └── visualization  <- Scripts to create exploratory and results oriented visualizations
 │       └── visualize.py
 │
-└── tox.ini            <- tox file with settings for running tox; see tox.testrun.org
+└── tox.ini            <- tox file with settings for running tox; see tox.readthedocs.io
 ```
 
 ## Contributing

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -120,7 +120,7 @@ cookiecutter https://github.com/drivendata/cookiecutter-data-science
 │   └── visualization  <- Scripts to create exploratory and results oriented visualizations
 │       └── visualize.py
 │
-└── tox.ini            <- tox file with settings for running tox; see tox.testrun.org
+└── tox.ini            <- tox file with settings for running tox; see tox.readthedocs.io
 ```
 
 ## Opinions

--- a/{{ cookiecutter.repo_name }}/README.md
+++ b/{{ cookiecutter.repo_name }}/README.md
@@ -49,7 +49,7 @@ Project Organization
     │   └── visualization  <- Scripts to create exploratory and results oriented visualizations
     │       └── visualize.py
     │
-    └── tox.ini            <- tox file with settings for running tox; see tox.testrun.org
+    └── tox.ini            <- tox file with settings for running tox; see tox.readthedocs.io
 
 
 --------


### PR DESCRIPTION
Use https://tox.readthedocs.io/ instead of insecure and somehow confused  tox.testrun.org.

This was already mentioned in the issues and it looks like there was respective pull request, but for a reason I don't see better link to the tox project.