### PR TITLE
Fixed failing tests on Windows

### DIFF
--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -8,15 +8,10 @@ def no_curlies(filepath):
     """ Utility to make sure no curly braces appear in a file.
         That is, was Jinja able to render everything?
     """
-    with open(filepath, 'r') as f:
+    with open(filepath, "r") as f:
         data = f.read()
 
-    template_strings = [
-        '{{',
-        '}}',
-        '{%',
-        '%}'
-    ]
+    template_strings = ["{{", "}}", "{%", "%}"]
 
     template_strings_in_file = [s in data for s in template_strings]
     return not any(template_strings_in_file)
@@ -26,86 +21,84 @@ def no_curlies(filepath):
 class TestCookieSetup(object):
     def test_project_name(self):
         project = self.path
-        if pytest.param.get('project_name'):
-            name = system_check('DrivenData')
+        if pytest.param.get("project_name"):
+            name = system_check("DrivenData")
             assert project.name == name
         else:
-            assert project.name == 'project_name'
+            assert project.name == "project_name"
 
     def test_author(self):
-        setup_ = str(self.path / 'setup.py')
-        args = ['python', setup_, '--author']
-        p = check_output(args).decode('ascii').strip()
-        if pytest.param.get('author_name'):
-            assert p == 'DrivenData'
+        setup_ = self.path / "setup.py"
+        args = ["python", str(setup_), "--author"]
+        p = check_output(args).decode("ascii").strip()
+        if pytest.param.get("author_name"):
+            assert p == "DrivenData"
         else:
-            assert p == 'Your name (or your organization/company/team)'
+            assert p == "Your name (or your organization/company/team)"
 
     def test_readme(self):
-        readme_path = self.path / 'README.md'
+        readme_path = self.path / "README.md"
         assert readme_path.exists()
         assert no_curlies(readme_path)
-        if pytest.param.get('project_name'):
+        if pytest.param.get("project_name"):
             with open(readme_path) as fin:
-                assert 'DrivenData' == next(fin).strip()
+                assert "DrivenData" == next(fin).strip()
 
     def test_setup(self):
-        setup_ = str(self.path / 'setup.py')
-        args = ['python', setup_, '--version']
-        p = check_output(args).decode('ascii').strip()
-        assert p == '0.1.0'
+        setup_ = self.path / "setup.py"
+        args = ["python", str(setup_), "--version"]
+        p = check_output(args).decode("ascii").strip()
+        assert p == "0.1.0"
 
     def test_license(self):
-        license_path = self.path / 'LICENSE'
+        license_path = self.path / "LICENSE"
         assert license_path.exists()
         assert no_curlies(license_path)
 
     def test_license_type(self):
-        setup_ = str(self.path / 'setup.py')
-        args = ['python', setup_, '--license']
-        p = check_output(args).decode('ascii').strip()
-        if pytest.param.get('open_source_license'):
-            assert p == 'BSD-3'
+        setup_ = self.path / "setup.py"
+        args = ["python", str(setup_), "--license"]
+        p = check_output(args).decode("ascii").strip()
+        if pytest.param.get("open_source_license"):
+            assert p == "BSD-3"
         else:
-            assert p == 'MIT'
+            assert p == "MIT"
 
     def test_requirements(self):
-        reqs_path = self.path / 'requirements.txt'
+        reqs_path = self.path / "requirements.txt"
         assert reqs_path.exists()
         assert no_curlies(reqs_path)
-        if pytest.param.get('python_interpreter'):
+        if pytest.param.get("python_interpreter"):
             with open(reqs_path) as fin:
                 lines = list(map(lambda x: x.strip(), fin.readlines()))
-            assert 'pathlib2' in lines
+            assert "pathlib2" in lines
 
     def test_makefile(self):
-        makefile_path = self.path / 'Makefile'
+        makefile_path = self.path / "Makefile"
         assert makefile_path.exists()
         assert no_curlies(makefile_path)
 
     def test_folders(self):
         expected_dirs = [
-            'data',
-            'data/external',
-            'data/interim',
-            'data/processed',
-            'data/raw',
-            'docs',
-            'models',
-            'notebooks',
-            'references',
-            'reports',
-            'reports/figures',
-            'src',
-            'src/data',
-            'src/features',
-            'src/models',
-            'src/visualization',
+            "data",
+            "data/external",
+            "data/interim",
+            "data/processed",
+            "data/raw",
+            "docs",
+            "models",
+            "notebooks",
+            "references",
+            "reports",
+            "reports/figures",
+            "src",
+            "src/data",
+            "src/features",
+            "src/models",
+            "src/visualization",
         ]
 
-        ignored_dirs = [
-            str(self.path)
-        ]
+        ignored_dirs = [str(self.path)]
 
         abs_expected_dirs = [str(self.path / d) for d in expected_dirs]
         abs_dirs, _, _ = list(zip(*os.walk(self.path)))

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -8,10 +8,15 @@ def no_curlies(filepath):
     """ Utility to make sure no curly braces appear in a file.
         That is, was Jinja able to render everything?
     """
-    with open(filepath, "r") as f:
+    with open(filepath, 'r') as f:
         data = f.read()
 
-    template_strings = ["{{", "}}", "{%", "%}"]
+    template_strings = [
+        '{{',
+        '}}',
+        '{%',
+        '%}'
+    ]
 
     template_strings_in_file = [s in data for s in template_strings]
     return not any(template_strings_in_file)
@@ -21,85 +26,88 @@ def no_curlies(filepath):
 class TestCookieSetup(object):
     def test_project_name(self):
         project = self.path
-        if pytest.param.get("project_name"):
-            name = system_check("DrivenData")
+        if pytest.param.get('project_name'):
+            name = system_check('DrivenData')
             assert project.name == name
         else:
-            assert project.name == "project_name"
+            assert project.name == 'project_name'
 
     def test_author(self):
-        setup_ = self.path / "setup.py"
-        args = ["python", str(setup_), "--author"]
-        p = check_output(args).decode("ascii").strip()
-        if pytest.param.get("author_name"):
-            assert p == "DrivenData"
+        setup_ = self.path / 'setup.py'
+        args = ['python', str(setup_), '--author']
+        p = check_output(args).decode('ascii').strip()
+        if pytest.param.get('author_name'):
+            assert p == 'DrivenData'
         else:
-            assert p == "Your name (or your organization/company/team)"
+            assert p == 'Your name (or your organization/company/team)'
 
     def test_readme(self):
-        readme_path = self.path / "README.md"
+        readme_path = self.path / 'README.md'
         assert readme_path.exists()
         assert no_curlies(readme_path)
-        if pytest.param.get("project_name"):
+        if pytest.param.get('project_name'):
             with open(readme_path) as fin:
-                assert "DrivenData" == next(fin).strip()
+                assert 'DrivenData' == next(fin).strip()
 
     def test_setup(self):
-        setup_ = self.path / "setup.py"
-        args = ["python", str(setup_), "--version"]
-        p = check_output(args).decode("ascii").strip()
-        assert p == "0.1.0"
+        setup_ = self.path / 'setup.py'
+        args = ['python', str(setup_), '--version']
+        p = check_output(args).decode('ascii').strip()
+        assert p == '0.1.0'
 
     def test_license(self):
-        license_path = self.path / "LICENSE"
+        license_path = self.path / 'LICENSE'
         assert license_path.exists()
         assert no_curlies(license_path)
 
     def test_license_type(self):
-        setup_ = self.path / "setup.py"
-        args = ["python", str(setup_), "--license"]
-        p = check_output(args).decode("ascii").strip()
-        if pytest.param.get("open_source_license"):
-            assert p == "BSD-3"
+        setup_ = self.path / 'setup.py'
+        args = ['python', str(setup_), '--license']
+        p = check_output(args).decode('ascii').strip()
+        if pytest.param.get('open_source_license'):
+            assert p == 'BSD-3'
         else:
-            assert p == "MIT"
+            assert p == 'MIT'
 
     def test_requirements(self):
-        reqs_path = self.path / "requirements.txt"
+        reqs_path = self.path / 'requirements.txt'
         assert reqs_path.exists()
         assert no_curlies(reqs_path)
-        if pytest.param.get("python_interpreter"):
+        if pytest.param.get('python_interpreter'):
             with open(reqs_path) as fin:
                 lines = list(map(lambda x: x.strip(), fin.readlines()))
-            assert "pathlib2" in lines
+            assert 'pathlib2' in lines
 
     def test_makefile(self):
-        makefile_path = self.path / "Makefile"
+        makefile_path = self.path / 'Makefile'
         assert makefile_path.exists()
         assert no_curlies(makefile_path)
 
     def test_folders(self):
         expected_dirs = [
-            "data",
-            "data/external",
-            "data/interim",
-            "data/processed",
-            "data/raw",
-            "docs",
-            "models",
-            "notebooks",
-            "references",
-            "reports",
-            "reports/figures",
-            "src",
-            "src/data",
-            "src/features",
-            "src/models",
-            "src/visualization",
+            'data',
+            'data/external',
+            'data/interim',
+            'data/processed',
+            'data/raw',
+            'docs',
+            'models',
+            'notebooks',
+            'references',
+            'reports',
+            'reports/figures',
+            'src',
+            'src/data',
+            'src/features',
+            'src/models',
+            'src/visualization',
         ]
 
-        ignored_dirs = [str(self.path)]
+        ignored_dirs = [
+            str(self.path)
+        ]
 
         abs_expected_dirs = [str(self.path / d) for d in expected_dirs]
         abs_dirs, _, _ = list(zip(*os.walk(self.path)))
         assert len(set(abs_expected_dirs + ignored_dirs) - set(abs_dirs)) == 0
+

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -33,7 +33,7 @@ class TestCookieSetup(object):
             assert project.name == 'project_name'
 
     def test_author(self):
-        setup_ = self.path / 'setup.py'
+        setup_ = str(self.path / 'setup.py')
         args = ['python', setup_, '--author']
         p = check_output(args).decode('ascii').strip()
         if pytest.param.get('author_name'):
@@ -50,7 +50,7 @@ class TestCookieSetup(object):
                 assert 'DrivenData' == next(fin).strip()
 
     def test_setup(self):
-        setup_ = self.path / 'setup.py'
+        setup_ = str(self.path / 'setup.py')
         args = ['python', setup_, '--version']
         p = check_output(args).decode('ascii').strip()
         assert p == '0.1.0'
@@ -61,7 +61,7 @@ class TestCookieSetup(object):
         assert no_curlies(license_path)
 
     def test_license_type(self):
-        setup_ = self.path / 'setup.py'
+        setup_ = str(self.path / 'setup.py')
         args = ['python', setup_, '--license']
         p = check_output(args).decode('ascii').strip()
         if pytest.param.get('open_source_license'):
@@ -110,4 +110,3 @@ class TestCookieSetup(object):
         abs_expected_dirs = [str(self.path / d) for d in expected_dirs]
         abs_dirs, _, _ = list(zip(*os.walk(self.path)))
         assert len(set(abs_expected_dirs + ignored_dirs) - set(abs_dirs)) == 0
-


### PR DESCRIPTION
Casting Path objects to strings due to an issue with `WindowsPath`:
```
TypeError: argument of type 'WindowsPath' is not iterable
```

Fixes #215 