### PR TITLE
updated .gitignore

### DIFF
--- a/{{ cookiecutter.repo_name }}/.gitignore
+++ b/{{ cookiecutter.repo_name }}/.gitignore
@@ -1,3 +1,10 @@
+################# USER ADDED ########################
+# add your files to ignore here
+
+
+#####################################################
+################## DEFAULTS #########################
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
On complicated projects, I used to get confused on what I added to the .gitignore and what was recommended. There was times that I might want to remove something that I previously added. 

Adding some basic annotations helped me keep track of what I added and what was set in place by the recommended .gitignore file.