### PR TITLE
Update suggestion to keep using deprecated cookiecutter template

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,3 +1,3 @@
 {
-    "DEPRECATED": "Use of cookiecutter command is deprecated; please use ccds command for the new version, or add @v1 to your git URL to use deprecated template."
+    "DEPRECATED": "Use of the `cookiecutter` command is deprecated. Please use `ccds` in place of `cookiecutter`. To continue using the deprecated template, use `cookiecutter ... -c v1`."
 }


### PR DESCRIPTION
#162 uses `ccds` instead of `cookiecutter`. We want to have an informative message that instructs people who try to use `cookiecutter` to either a) switch to using `ccds` b) an option to continue using the deprecated `cookiecutter`. This PR simply adds that command.

```
cookiecutter https://...@v1
```
does not work
> subprocess.CalledProcessError: Command '['git', 'clone', 'https://github.com/r-b-g-b/cookiecutter-data-science@v1']' returned non-zero exit status 128.

since `git clone https://...@v1` fails.

Instead the cookiecutter docs state we can use

```
cookiecutter --help
  -c, --checkout TEXT        branch, tag or commit to checkout after git clone
```

I tested this out on [my fork](https://github.com/r-b-g-b/cookiecutter-data-science) of this repo. I added a `v1` tag on `master` and a `v2` tag on `new-cli`.

```
cookiecutter https://github.com/r-b-g-b/cookiecutter-data-science -c v2

DEPRECATED [Use of the `cookiecutter` command is deprecated. Please use `ccds` in place of `cookiecutter`. To continue using the deprecated template, use `cookiecutter ... -c v1`.]:
Unable to create project directory '{{ cookiecutter.repo_name }}'
Error message: 'collections.OrderedDict object' has no attribute 'repo_name'
Context: {
    "cookiecutter": {
        "DEPRECATED": "Use of the `cookiecutter` command is deprecated. Please use `ccds` in place of `cookiecutter`. To continue using the deprecated template, use `cookiecutter ... -c v1`.",
        "_template": "https://github.com/r-b-g-b/cookiecutter-data-science"
    }
}
```

(Not sure what to do about the `Error message: 'collections.OrderedDict object' has no attribute 'repo_name'` @pjbull thoughts?)

```
ccds https://github.com/r-b-g-b/cookiecutter-data-science -c v2
You've downloaded /home/robert/.cookiecutters/cookiecutter-data-science before. Is it okay to delete and re-download it? [yes]: yes
project_name [project_name]:
repo_name [project_name]:
module_name [project_name]:
author_name [Your name (or your organization/company/team)]:
description [A short description of the project.]:
python_version_number [3.7]:
Select dataset_storage:
1 - none
2 - azure
3 - s3
4 - gcs
...
```

(When merge #162 to `master` and tag the previous version as `v1`, omitting the `-c` flag will default to the `master` branch as intended.)