### PR TITLE
Lint, format, license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,0 @@
-The MIT License (MIT)
-Copyright (c) 2016 DrivenData, Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,8 @@
+The MIT License (MIT)
+Copyright (c) 2016 DrivenData, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ which is available now.
 ### The resulting directory structure
 ------------
 
-The directory structure of your new project looks like this: 
+The directory structure of your new project looks like this:
 
 ```
 ├── LICENSE
@@ -64,6 +64,8 @@ The directory structure of your new project looks like this:
 │                         the creator's initials, and a short `-` delimited description, e.g.
 │                         `1.0-jqp-initial-data-exploration`.
 │
+├── pyproject.toml     <- Project configuration file with settings for running black; see setuptools.readthedocs.io
+│
 ├── references         <- Data dictionaries, manuals, and all other explanatory materials.
 │
 ├── reports            <- Generated analysis as HTML, PDF, LaTeX, etc.
@@ -71,6 +73,8 @@ The directory structure of your new project looks like this:
 │
 ├── requirements.txt   <- The requirements file for reproducing the analysis environment, e.g.
 │                         generated with `pip freeze > requirements.txt`
+│
+├── setup.cfg          <- Configuration file for flake8 and pep8
 │
 ├── setup.py           <- makes project pip installable (pip install -e .) so src can be imported
 │

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ _A logical, reasonably standardized, but flexible project structure for doing an
 
 ### Requirements to use the cookiecutter template:
 -----------
- - Python 2.7 or 3.5+
+ - Python 3.7+
  - [Cookiecutter Python package](http://cookiecutter.readthedocs.org/en/latest/installation.html) >= 1.4.0: This can be installed with pip by or conda depending on how you manage your Python packages:
 
 ``` bash

--- a/ccds.json
+++ b/ccds.json
@@ -4,7 +4,7 @@
     "module_name": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
     "author_name": "Your name (or your organization/company/team)",
     "description": "A short description of the project.",
-    "python_version_number": "3.7",
+    "python_version_number": "3.10",
     "dataset_storage": [
         {"none": "none"},
         {"azure": {"container": "container-name"}},
@@ -26,5 +26,5 @@
         "none",
         "basic"
     ],
-    "open_source_license": ["MIT", "BSD-3-Clause", "No license file"]
+    "open_source_license": ["No license file", "MIT", "BSD-3-Clause"]
 }

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -58,7 +58,7 @@ With this in mind, we've created a data science cookiecutter template for projec
 
 ### Requirements
 
- - Python 2.7 or 3.5
+ - Python >= 3.7
  - [cookiecutter Python package](http://cookiecutter.readthedocs.org/en/latest/installation.html) >= 1.4.0: `pip install cookiecutter`
 
 

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -71,6 +71,8 @@ def verify_files(root, config):
         "Makefile",
         "README.md",
         "setup.py",
+        "pyproject.toml",
+        "setup.cfg",
         ".env",
         ".gitignore",
         "data/external/.gitkeep",

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean data lint requirements sync_data_down sync_data_up
+.PHONY: clean data lint format requirements sync_data_down sync_data_up
 
 #################################################################################
 # GLOBALS                                                                       #
@@ -36,6 +36,10 @@ clean:
 ## Lint using flake8
 lint:
 	flake8 {{ cookiecutter.module_name }}
+
+## Format with black
+format:
+	black --config pyproject.toml {{ cookiecutter.module_name }}
 
 {% if not cookiecutter.dataset_storage.none %}
 ## Download Data from storage system
@@ -82,6 +86,10 @@ create_environment:
 	{% endif %}
 {% endif %}
 
+## Wrapper for format and lint
+pre-commit:
+	make format
+	make lint
 
 #################################################################################
 # PROJECT RULES                                                                 #

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -33,11 +33,13 @@ clean:
 	find . -type f -name "*.py[co]" -delete
 	find . -type d -name "__pycache__" -delete
 
-## Lint using flake8
+## Lint using flake8 and black (use `make format` to do formatting)
 lint:
 	flake8 {{ cookiecutter.module_name }}
+	black --check --config pyproject.toml {{ cookiecutter.module_name }}
 
-## Format with black
+
+## Format source code with black
 format:
 	black --config pyproject.toml {{ cookiecutter.module_name }}
 
@@ -86,10 +88,6 @@ create_environment:
 	{% endif %}
 {% endif %}
 
-## Wrapper for format and lint
-pre-commit:
-	make format
-	make lint
 
 #################################################################################
 # PROJECT RULES                                                                 #

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.black]
+line-length = 99
+target-version = ['py36', 'py37', 'py38']
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.venv
+)/
+'''

--- a/{{ cookiecutter.repo_name }}/setup.cfg
+++ b/{{ cookiecutter.repo_name }}/setup.cfg
@@ -1,0 +1,8 @@
+[flake8]
+ignore = E731,E266,E501,C901,W503
+max-line-length = 99
+exclude = .git,notebooks,references,models,data
+
+[pep8]
+max-line-length = 99
+exclude = .git,notebooks,references,models,data


### PR DESCRIPTION
- Adds formatting commands (`black`) and pre-commit wrapper
- Configuration file format defaults (`setup.cfg` and `pyproject.toml`)
- Support Python 3.8, remove 3.5
- Default to no license (rather than MIT)