### PR TITLE
adding Citation files to cookiecutter-data-science template

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -2,9 +2,12 @@
     "project_name": "project_name",
     "repo_name": "{{ cookiecutter.project_name.lower().replace(' ', '_') }}",
     "author_name": "Your name (or your organization/company/team)",
+    "orcid": "Your ORCID url",
     "description": "A short description of the project.",
     "open_source_license": ["MIT", "BSD-3-Clause", "No license file"],
     "s3_bucket": "[OPTIONAL] your-bucket-for-syncing-data (do not include 's3://')",
+    "vcs": ["Github", "Gitlab", "None"],
+    "vcs_username": "Your VCS username",
     "aws_profile": "default",
     "python_interpreter": ["python3", "python"]
 }

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -111,3 +111,7 @@ class TestCookieSetup(object):
         abs_dirs, _, _ = list(zip(*os.walk(self.path)))
         assert len(set(abs_expected_dirs + ignored_dirs) - set(abs_dirs)) == 0
 
+    def test_citationfile(self):
+        citation_path = self.path / 'CITATION.cff'
+        assert citation_path.exists()
+        assert no_curlies(citation_path)

--- a/{{ cookiecutter.repo_name }}/CITATION.cff
+++ b/{{ cookiecutter.repo_name }}/CITATION.cff
@@ -1,0 +1,17 @@
+cff-version: 1.2.0
+message: "If you use this data/software, please cite it as below."
+authors:
+- family-names: "{{ cookiecutter.author_name.split()[0] }}"
+  given-names: "{{ cookiecutter.author_name.split()[1] }}"
+  orcid: "{{ cookiecutter.orcid }}"
+title: "{{ cookiecutter.project_name.lower().replace(' ', '_') }}"
+version: 0.0.1
+date-released: ""
+doi: ""
+{% if cookiecutter.vcs == 'Github' %}
+url: "{{ 'https://github.com/'~cookiecutter.vcs_username }}"
+{% elif cookiecutter.vcs == 'Gitlab' %}
+url: "{{ 'https://gitlab.com/'~cookiecutter.vcs_username }}"
+{% else %}
+url: ""
+{% endif %}


### PR DESCRIPTION
CITATION.cff files are plain text files with human- and machine-readable citation information for software (and datasets). Code developers can include them in their repositories to let others know how to correctly cite their software.

It is very easy to correctly cite a paper: all the necessary information (metadata) can be found on the title page or the article website. Software and datasets have no title page, the relevant information is often less obvious.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files