### PR TITLE
Adding the ability to sort imports in src using isort

### DIFF
--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -37,6 +37,10 @@ clean:
 ## Lint using flake8
 lint:
 	flake8 src
+	
+## Sort imports using isort
+sort_imports:
+	isort src
 
 ## Upload Data to S3
 sync_data_to_s3:

--- a/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/{{ cookiecutter.repo_name }}/requirements.txt
@@ -7,6 +7,7 @@ Sphinx
 coverage
 awscli
 flake8
+isort
 python-dotenv>=0.5.1
 {% if cookiecutter.python_interpreter != 'python3' %}
 


### PR DESCRIPTION
This tiny PR adds a rule to the `Makefile` to sort the imports of `src` using [`isort`](https://github.com/PyCQA/isort). 