### PR TITLE
Removing deprecation message from v2

### DIFF
--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,24 +1,4 @@
-def deprecation_warning():
-    print(
-        """
+# Functions here run before the project is generated.
 
-=============================================================================
-*** DEPRECATION WARNING ***
-
-Cookiecutter data science is moving to v2 soon, which will entail using
-the command `ccds ...` rather than `cookiecutter ...`. The cookiecutter command
-will continue to work, and this version of the template will still be available.
-To use the legacy template, you will need to explicitly use `-c v1` to select it.
-
-Please update any scripts/automation you have to append the `-c v1` option,
-which is available now.
-
-For example:
-    cookiecutter -c v1 https://github.com/drivendata/cookiecutter-data-science
-=============================================================================
-
-    """
-    )
-
-
-deprecation_warning()
+# For the use of these hooks, see
+# See https://cookiecutter.readthedocs.io/en/1.7.2/advanced/hooks.html


### PR DESCRIPTION
Removing the deprecation message from the pre-rendering hook (and since there's nothing left, adding a pointer to the documentation)

Closes #281