### PR TITLE
Update Makefile help command to work on all platforms

### DIFF
--- a/tests/conda_harness.sh
+++ b/tests/conda_harness.sh
@@ -29,6 +29,7 @@ then
     sudo chown -R $USER /usr/local/miniconda
 fi
 
+make
 make create_environment
 conda activate $PROJECT_NAME
 make requirements

--- a/tests/pipenv_harness.sh
+++ b/tests/pipenv_harness.sh
@@ -19,6 +19,7 @@ source $CCDS_ROOT/test_functions.sh
 
 # navigate to the generated project and run make commands 
 cd $1
+make
 make create_environment
 
 # can happen outside of environment since pipenv knows based on Pipfile

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -172,9 +172,14 @@ def verify_makefile_commands(root, config):
     # normally hidden by pytest except in failure we want this displayed
     print("PATH=", os.getenv("PATH"))
     print("\n======================= STDOUT ======================")
-    print(result.stdout.decode(encoding))
+    stdout_output = result.stdout.decode(encoding)
+    print(stdout_output)
 
     print("\n======================= STDERR ======================")
     print(result.stderr.decode(encoding))
+
+    # Check that makefile help ran successfully
+    assert "Available rules:" in stdout_output
+    assert "clean                    Delete all compiled Python files" in stdout_output
 
     assert result_returncode == 0

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -137,6 +137,7 @@ def verify_files(root, config):
 
 def verify_makefile_commands(root, config):
     """Actually shell out to bash and run the make commands for:
+    - blank command listing commands
     - create_environment
     - requirements
     Ensure that these use the proper environment.

--- a/tests/virtualenv_harness.sh
+++ b/tests/virtualenv_harness.sh
@@ -41,6 +41,7 @@ then
     source `which virtualenvwrapper.sh`
 fi
 
+make
 make create_environment
 
 # workon not sourced

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -110,15 +110,13 @@ data: requirements
 .DEFAULT_GOAL := help
 
 define PRINT_HELP_PYSCRIPT
-import re, sys
-
-for line in sys.stdin:
-	match = re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line)
-	if match:
-		target, help = match.groups()
-		print("%-20s %s" % (target, help))
+import re, sys; \
+lines = '\n'.join([line for line in sys.stdin]); \
+matches = re.findall(r'\n## (.*)\n[\s\S]+?\n([a-zA-Z_-]+):', lines); \
+print('Available rules:\n'); \
+print('\n'.join(['{:25}{}'.format(*reversed(match)) for match in matches]))
 endef
 export PRINT_HELP_PYSCRIPT
 
 help:
-	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
+	@python -c "${PRINT_HELP_PYSCRIPT}" < $(MAKEFILE_LIST)


### PR DESCRIPTION
Closes #221

This PR switches the style and format of the python script in the Makefile that generates the help message text. The old script was not formatted correctly to regex match commented commands written with the structure we use in our Makefile, and leveraged `$$VAR` syntax in the command itself that does not work in Windows environments.

In order for this to work in the intended way, we had to treat the Python script as a single line - otherwise, because we're invoking the script as a command, newlines would trigger running a new command entirely. That's why the script ends each line with `; \`.