### PR TITLE
Fix screencast generation

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -131,10 +131,7 @@ ccds https://github.com/drivendata/cookiecutter-data-science
 
 ### Example
 
-{%
-   include-markdown "./_partials/termynal.md"
-%}
-
+<!-- TERMYNAL OUTPUT -->
 
 ## Directory structure
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -15,8 +15,6 @@ extra_css:
   - css/extra.css
 extra_javascript:
   - js/extra.js
-exclude_docs: |
-  _partials/termynal.md
 markdown_extensions:
   - admonition
   - pymdownx.details

--- a/docs/scripts/generate-termynal.py
+++ b/docs/scripts/generate-termynal.py
@@ -143,7 +143,10 @@ if __name__ == "__main__":
 else:
     import mkdocs_gen_files
 
-    with mkdocs_gen_files.open(
-        Path(CCDS_ROOT / "docs" / "docs" / "_partials" / "termynal.md"), "w"
-    ) as f:
-        f.write(render_termynal())
+    with mkdocs_gen_files.open("index.md", "r") as f:
+        index = f.read()
+
+    index = index.replace("<!-- TERMYNAL OUTPUT -->", render_termynal())
+
+    with mkdocs_gen_files.open("index.md", "w") as f:
+        f.write(index)


### PR DESCRIPTION
Closes #342 

This PR fixes a bug during screencast generation that left a stray `termynal.md` file that gets included in the docs tree and displayed as its own page. Instead, we use `mkdocs-gen-files` as intended with a temporary string filename rather than an explicit path, and we temporarily modify `index.md` in place during the build process to produce the final output.