### PR TITLE
Minor CSS Tweaks

### DIFF
--- a/docs/docs/css/extra.css
+++ b/docs/docs/css/extra.css
@@ -35,10 +35,20 @@
     word-break: break-word;
 }
 
+.md-typeset pre {
+    display: flex;
+}
+
 .md-typeset code {
     font-size: .8em;
     background-color: #f5f5f5;
     color: #193d3d;
+    min-width: 35rem;
+    flex-shrink: 1;
+}
+
+.js .md-typeset .tabbed-labels {
+    max-width: 35rem;
 }
 
 .md-typeset .admonition.info,
@@ -48,6 +58,7 @@
 .md-typeset .info > .admonition-title,
 .md-typeset .info > summary {
   background-color: #328F9726;
+  border-color: #328F97;
 }
 
 .md-typeset .info > .admonition-title::before,

--- a/docs/docs/css/extra.css
+++ b/docs/docs/css/extra.css
@@ -52,17 +52,23 @@
 }
 
 .md-typeset .admonition.info,
-.md-typeset details.info {
+.md-typeset details.info,
+.md-typeset .admonition.note,
+.md-typeset details.note {
   border-color: #328F97;
 }
 .md-typeset .info > .admonition-title,
-.md-typeset .info > summary {
+.md-typeset .info > summary,
+.md-typeset .note > .admonition-title,
+.md-typeset .note > summary {
   background-color: #328F9726;
   border-color: #328F97;
 }
 
 .md-typeset .info > .admonition-title::before,
-.md-typeset .info > summary::before {
+.md-typeset .info > summary::before,
+.md-typeset .note > .admonition-title::before,
+.md-typeset .note > summary::before {
   background-color: #328F97;
 }
 


### PR DESCRIPTION
Fixes a few issues where render-deployed version looks different from local.

Specifically, this PR fixes:

* Border color on infobox
* Sizing of code blocks (min-width 35rem, but flexes to grow)
  * Makes sizing of multi-tabbed menu same as underlying code box