### PR TITLE
feat: use 'uv run python' as interpreter when uv is selected

### DIFF
--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -4,7 +4,11 @@
 
 PROJECT_NAME = {{ cookiecutter.repo_name }}
 PYTHON_VERSION = {{ cookiecutter.python_version_number }}
+{% if cookiecutter.environment_manager == 'uv' %}
+PYTHON_INTERPRETER = uv run python
+{% else %}
 PYTHON_INTERPRETER = python
+{% endif %}
 
 #################################################################################
 # COMMANDS                                                                      #


### PR DESCRIPTION
This PR updates the `Makefile` template to define `PYTHON_INTERPRETER` as `uv run python` when `uv` is selected as the environment manager.

## Context
Currently, when using `uv`, the user still relies on the system python or must manually activate the virtual environment (`source .venv/bin/activate`) before running make commands like `make data`.

Modern `uv` workflows encourage using `uv run` to execute scripts in the project environment ephemerally, ensuring reproducibility and reducing friction.