### PR TITLE
Tweak test harnesses to address Windows actions runner failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,6 +107,13 @@ jobs:
           # Set bash executable explicitly since Make may pick wrong shell
           echo "BASH_EXECUTABLE=$(which bash)" >> "$GITHUB_ENV"
 
+          # Fix conda prune issues on Windows
+          echo "CONDA_SOLVER=classic" >> "$GITHUB_ENV"
+          echo "CONDA_PKGS_DIRS=${CONDA}/pkgs" >> "$GITHUB_ENV"
+          
+          # Fix ruff config discovery for pixi
+          echo "RUFF_CONFIG=pyproject.toml" >> "$GITHUB_ENV"
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,13 +106,12 @@ jobs:
           echo "${CONDA}\Scripts" >> $GITHUB_PATH
           # Set bash executable explicitly since Make may pick wrong shell
           echo "BASH_EXECUTABLE=$(which bash)" >> "$GITHUB_ENV"
-
-          # Fix conda prune issues on Windows
-          echo "CONDA_SOLVER=classic" >> "$GITHUB_ENV"
-          echo "CONDA_PKGS_DIRS=${CONDA}/pkgs" >> "$GITHUB_ENV"
           
           # Fix ruff config discovery for pixi
           echo "RUFF_CONFIG=pyproject.toml" >> "$GITHUB_ENV"
+
+          # Add small delay for conda operations on Windows
+          echo "CONDA_INSTALL_DELAY=2" >> "$GITHUB_ENV"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,9 +107,6 @@ jobs:
           # Set bash executable explicitly since Make may pick wrong shell
           echo "BASH_EXECUTABLE=$(which bash)" >> "$GITHUB_ENV"
           
-          # Fix ruff config discovery for pixi
-          echo "RUFF_CONFIG=pyproject.toml" >> "$GITHUB_ENV"
-
           # Add small delay for conda operations on Windows
           echo "CONDA_INSTALL_DELAY=2" >> "$GITHUB_ENV"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,7 +106,6 @@ jobs:
           echo "${CONDA}\Scripts" >> $GITHUB_PATH
           # Set bash executable explicitly since Make may pick wrong shell
           echo "BASH_EXECUTABLE=$(which bash)" >> "$GITHUB_ENV"
-          
           # Add small delay for conda operations on Windows
           echo "CONDA_INSTALL_DELAY=2" >> "$GITHUB_ENV"
 

--- a/tests/conda_harness.sh
+++ b/tests/conda_harness.sh
@@ -32,6 +32,10 @@ fi
 
 make
 make create_environment
+# Add delay on Windows to let conda settle
+if [[ ! -z "${CONDA_INSTALL_DELAY}" ]]; then
+    sleep ${CONDA_INSTALL_DELAY}
+fi
 conda activate $PROJECT_NAME
 make requirements
 make lint

--- a/tests/conda_harness.sh
+++ b/tests/conda_harness.sh
@@ -33,8 +33,8 @@ fi
 make
 make create_environment
 # Add delay on Windows to let conda settle
-if [[ ! -z "${CONDA_INSTALL_DELAY}" ]]; then
-    sleep ${CONDA_INSTALL_DELAY}
+if [[ -n "${CONDA_INSTALL_DELAY}" && "${CONDA_INSTALL_DELAY}" =~ ^[0-9]+$ ]]; then
+    sleep "${CONDA_INSTALL_DELAY}"
 fi
 conda activate $PROJECT_NAME
 make requirements

--- a/tests/pixi_harness.sh
+++ b/tests/pixi_harness.sh
@@ -51,11 +51,15 @@ if [ -d ".pixi" ]; then
     echo "Removing Ruff config files under .pixi to avoid discovery"
     find .pixi \( -name ".ruff.toml" -o -name "ruff.toml" \) -print -delete
 fi
-pixi run python - <<'PY'
+RUFF_PATH="$(pixi run python - <<'PY'
 import shutil
-print(f"ruff which: {shutil.which('ruff')}")
+print(shutil.which("ruff") or "")
 PY
-pixi run ruff --version
+)"
+echo "ruff which: ${RUFF_PATH:-None}"
+if [ -n "$RUFF_PATH" ]; then
+    pixi run ruff --version
+fi
 
 pixi run make lint
 pixi run make format

--- a/tests/pixi_harness.sh
+++ b/tests/pixi_harness.sh
@@ -22,6 +22,9 @@ function finish {
     if [ -f "pixi.lock" ]; then
         rm -f pixi.lock
     fi
+    if [ -f ".ruff-empty.toml" ]; then
+        rm -f .ruff-empty.toml
+    fi
 }
 trap finish EXIT
 
@@ -46,29 +49,16 @@ if [ -f "$MODULE_NAME/config.py" ]; then
     pixi run python -c "from $MODULE_NAME import config"
 fi
 
-# Run linting and formatting through pixi without picking up .pixi/.ruff.toml configs.
-# If pyproject.toml exists, force it; otherwise run isolated with no config discovery.
-RUFF_FLAGS=()
+# Run linting/formatting through make, but force Ruff to ignore any .ruff.toml it discovers.
 if [ -f "pyproject.toml" ]; then
-    RUFF_FLAGS+=(--config pyproject.toml)
+    export RUFF_CONFIG="pyproject.toml"
 else
-    RUFF_FLAGS+=(--isolated)
+    : > .ruff-empty.toml
+    export RUFF_CONFIG=".ruff-empty.toml"
 fi
 
-RUFF_TARGETS=()
-if [ -f "pyproject.toml" ]; then
-    if [ -d "$MODULE_NAME" ]; then
-        RUFF_TARGETS+=("$MODULE_NAME")
-    fi
-    RUFF_TARGETS+=("pyproject.toml")
-elif [ -d "$MODULE_NAME" ]; then
-    RUFF_TARGETS+=("$MODULE_NAME")
-else
-    RUFF_TARGETS+=(".")
-fi
-
-pixi run ruff format --check "${RUFF_FLAGS[@]}" "${RUFF_TARGETS[@]}"
-pixi run ruff check "${RUFF_FLAGS[@]}" "${RUFF_TARGETS[@]}"
+pixi run make lint
+pixi run make format
 
 # Custom pixi test function to avoid issues with test_functions.sh
 # Check that python is available in pixi environment

--- a/tests/pixi_harness.sh
+++ b/tests/pixi_harness.sh
@@ -46,9 +46,29 @@ if [ -f "$MODULE_NAME/config.py" ]; then
     pixi run python -c "from $MODULE_NAME import config"
 fi
 
-# Run linting and formatting through pixi
-pixi run make lint
-pixi run make format
+# Run linting and formatting through pixi without picking up .pixi/.ruff.toml configs.
+# If pyproject.toml exists, force it; otherwise run isolated with no config discovery.
+RUFF_FLAGS=()
+if [ -f "pyproject.toml" ]; then
+    RUFF_FLAGS+=(--config pyproject.toml)
+else
+    RUFF_FLAGS+=(--isolated)
+fi
+
+RUFF_TARGETS=()
+if [ -f "pyproject.toml" ]; then
+    if [ -d "$MODULE_NAME" ]; then
+        RUFF_TARGETS+=("$MODULE_NAME")
+    fi
+    RUFF_TARGETS+=("pyproject.toml")
+elif [ -d "$MODULE_NAME" ]; then
+    RUFF_TARGETS+=("$MODULE_NAME")
+else
+    RUFF_TARGETS+=(".")
+fi
+
+pixi run ruff format --check "${RUFF_FLAGS[@]}" "${RUFF_TARGETS[@]}"
+pixi run ruff check "${RUFF_FLAGS[@]}" "${RUFF_TARGETS[@]}"
 
 # Custom pixi test function to avoid issues with test_functions.sh
 # Check that python is available in pixi environment

--- a/tests/pixi_harness.sh
+++ b/tests/pixi_harness.sh
@@ -22,9 +22,6 @@ function finish {
     if [ -f "pixi.lock" ]; then
         rm -f pixi.lock
     fi
-    if [ -f ".ruff-empty.toml" ]; then
-        rm -f .ruff-empty.toml
-    fi
 }
 trap finish EXIT
 
@@ -49,13 +46,16 @@ if [ -f "$MODULE_NAME/config.py" ]; then
     pixi run python -c "from $MODULE_NAME import config"
 fi
 
-# Run linting/formatting through make, but force Ruff to ignore any .ruff.toml it discovers.
-if [ -f "pyproject.toml" ]; then
-    export RUFF_CONFIG="pyproject.toml"
-else
-    : > .ruff-empty.toml
-    export RUFF_CONFIG=".ruff-empty.toml"
+# Run linting/formatting through make, but remove any .pixi ruff configs that Ruff may discover.
+if [ -d ".pixi" ]; then
+    echo "Removing Ruff config files under .pixi to avoid discovery"
+    find .pixi \( -name ".ruff.toml" -o -name "ruff.toml" \) -print -delete
 fi
+pixi run python - <<'PY'
+import shutil
+print(f"ruff which: {shutil.which('ruff')}")
+PY
+pixi run ruff --version
 
 pixi run make lint
 pixi run make format


### PR DESCRIPTION
Closes #432 

This PR makes two small tweaks to the ~Makefile~ Windows environment config in the actions test runners to address intermittent errors on Windows runners:

* Give conda on Windows runners some breathing room to settle by sleeping for 2 seconds
* Remove phantom ruff configs that supercede pyproject.toml on windows