### PR TITLE
Fail fast if repo_name directory already exists during prompts

### DIFF
--- a/ccds/monkey_patch.py
+++ b/ccds/monkey_patch.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 from pathlib import Path
 
 from cookiecutter.environment import StrictEnvironment
+from cookiecutter.exceptions import CookiecutterException
 from cookiecutter.exceptions import UndefinedVariableInTemplate
 from cookiecutter.generate import generate_context
 from cookiecutter.prompt import (
@@ -11,6 +12,15 @@ from cookiecutter.prompt import (
     render_variable,
 )
 from jinja2.exceptions import UndefinedError
+
+
+def _fail_if_repo_dir_exists(repo_name):
+    project_dir = Path.cwd() / repo_name
+    if project_dir.exists():
+        raise CookiecutterException(
+            f"Project directory '{project_dir}' already exists. "
+            "Please choose a different value for 'repo_name'."
+        )
 
 
 def _prompt_choice_and_subitems(cookiecutter_dict, env, key, options, no_input):
@@ -91,6 +101,8 @@ def prompt_for_config(context, no_input=False):
                     val = read_user_variable(key, val)
 
                 cookiecutter_dict[key] = val
+                if key == "repo_name":
+                    _fail_if_repo_dir_exists(val)
         except UndefinedError as err:
             msg = "Unable to render variable '{}'".format(key)
             raise UndefinedVariableInTemplate(msg, err, context)

--- a/tests/test_existing_directory.py
+++ b/tests/test_existing_directory.py
@@ -1,0 +1,39 @@
+from collections import OrderedDict
+
+import pytest
+from cookiecutter.exceptions import CookiecutterException
+
+from ccds import monkey_patch
+
+
+def test_fails_fast_if_repo_directory_already_exists(tmp_path, monkeypatch):
+    existing_repo_name = "existing-repo"
+    (tmp_path / existing_repo_name).mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    prompts_seen = []
+
+    def fake_read_user_variable(key, val):
+        prompts_seen.append(key)
+        if key == "project_name":
+            return "My Project"
+        if key == "repo_name":
+            return existing_repo_name
+        raise AssertionError("prompt_for_config should stop before this prompt")
+
+    monkeypatch.setattr(monkey_patch, "read_user_variable", fake_read_user_variable)
+
+    context = {
+        "cookiecutter": OrderedDict(
+            [
+                ("project_name", "project_name"),
+                ("repo_name", "repo_name"),
+                ("module_name", "module_name"),
+            ]
+        )
+    }
+
+    with pytest.raises(CookiecutterException, match="already exists"):
+        monkey_patch.prompt_for_config(context, no_input=False)
+
+    assert prompts_seen == ["project_name", "repo_name"]


### PR DESCRIPTION
## Summary
- add an early repo directory existence check in prompt flow, right after resolving `repo_name`
- raise a clear error immediately when the target project directory already exists
- add a focused regression test to verify prompt flow stops before asking later fields

## Why
Issue #282 requests checking for existing directory earlier so users do not answer the full prompt flow before seeing an output-directory collision error.

## Testing
- `. .venv/bin/activate && pytest tests/test_existing_directory.py -q`

## Notes
- #435 currently has open PRs (#407, #469), so this PR targets #282 as a non-duplicate enhancement.

Closes #282