### PR TITLE
Fix .gitignore ignoring /data/ folder

### DIFF
--- a/{{ cookiecutter.repo_name }}/.gitignore
+++ b/{{ cookiecutter.repo_name }}/.gitignore
@@ -1,5 +1,9 @@
 # Data
-/data/
+/data/**
+# Allow the folder
+!/data/**/
+# whitelist
+!/data/**/.gitkeep
 
 # Mac OS-specific storage files
 .DS_Store

--- a/{{ cookiecutter.repo_name }}/.gitignore
+++ b/{{ cookiecutter.repo_name }}/.gitignore
@@ -1,8 +1,6 @@
 # Data
 /data/**
-# Allow the folder
 !/data/**/
-# whitelist
 !/data/**/.gitkeep
 
 # Mac OS-specific storage files


### PR DESCRIPTION
### Why
Currently git ignores the data directory, even though there are .gitkeep file inside the /data/ subfolders.
This means that separate users will need to manually recreate the data folder and subfolders.

This is mentioned in a separate pull request: https://github.com/drivendataorg/cookiecutter-data-science/pull/223


### What changed
Modified the existing .gitignore line to use a fix outlined in the article: https://stackoverflow.com/questions/46301811/gitignore-all-files-in-folders-but-keep-folder-structure

from
```
# Data
/data/
```

to 
```
# Data
/data/**
!/data/**/
!/data/**/.gitkeep
```